### PR TITLE
Add intentionally failing check

### DIFF
--- a/.github/workflows/failing-check.yml
+++ b/.github/workflows/failing-check.yml
@@ -1,0 +1,16 @@
+name: Failing check
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: none
+
+jobs:
+  fail:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "This check is intentionally failing"
+          exit 1


### PR DESCRIPTION
Adds a workflow (`.github/workflows/failing-check.yml`) that always exits 1, so this PR has a red check.

Purpose: testing failing-check behavior. Not meant to be merged.